### PR TITLE
Add ordering and featured control to artworks

### DIFF
--- a/app/Filament/Resources/ArtistResource.php
+++ b/app/Filament/Resources/ArtistResource.php
@@ -60,10 +60,17 @@ class ArtistResource extends Resource
                                     ->directory('artworks')
                                     ->maxSize(5120)
                                     ->label('Imagens da Obra'),
+                                Forms\Components\Toggle::make('featured')
+                                    ->label('Destaque')
+                                    ->default(false),
+                                Forms\Components\TextInput::make('order')
+                                    ->numeric()
+                                    ->default(0)
+                                    ->label('Ordem'),
                             ])
                             ->columns(2)
                             ->defaultItems(1)
-                            ->reorderable(true)
+                            ->reorderable('order')
                             ->collapsible()
                             ->cloneable()
                             ->label('Obras do Artista')

--- a/app/Http/Controllers/ArtistController.php
+++ b/app/Http/Controllers/ArtistController.php
@@ -9,19 +9,25 @@ class ArtistController extends Controller
 {
     public function index()
     {
-        $artists = Artist::with('artworks')->get();
+        $artists = Artist::with(['artworks' => function ($query) {
+            $query->orderByDesc('featured')->orderBy('order');
+        }])->get();
         return view('artists.index', compact('artists'));
     }
 
     public function show($id)
     {
-        $artist = Artist::with('artworks')->findOrFail($id);
+        $artist = Artist::with(['artworks' => function ($query) {
+            $query->orderByDesc('featured')->orderBy('order');
+        }])->findOrFail($id);
         return view('artists.show', compact('artist'));
     }
 
     public function images($id)
     {
-        $artist = Artist::with('artworks')->findOrFail($id);
+        $artist = Artist::with(['artworks' => function ($query) {
+            $query->orderByDesc('featured')->orderBy('order');
+        }])->findOrFail($id);
         $images = [];
         // Imagens principais do artista
         if (is_array($artist->image)) {

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -24,6 +24,8 @@ class Artist extends Model
 
     public function artworks()
     {
-        return $this->hasMany(Artwork::class);
+        return $this->hasMany(Artwork::class)
+            ->orderByDesc('featured')
+            ->orderBy('order');
     }
 }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -17,11 +17,15 @@ class Artwork extends Model
         'images',
         'year',
         'technique',
-        'size_cm'
+        'size_cm',
+        'order',
+        'featured'
     ];
 
     protected $casts = [
-        'images' => 'array'
+        'images' => 'array',
+        'featured' => 'boolean',
+        'order' => 'integer'
     ];
 
     public function artist()

--- a/database/migrations/2025_08_10_000000_add_order_and_featured_to_artworks_table.php
+++ b/database/migrations/2025_08_10_000000_add_order_and_featured_to_artworks_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('artworks', function (Blueprint $table) {
+            $table->integer('order')->default(0);
+            $table->boolean('featured')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('artworks', function (Blueprint $table) {
+            $table->dropColumn(['order', 'featured']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- allow artworks to be ordered and marked as featured
- load artworks ordered by these fields
- expose featured and order fields in artist admin repeater
- migration to add `order` and `featured` columns

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a38828ca48325a157f09cde17b38e