### PR TITLE
Enable rich editor for artwork descriptions

### DIFF
--- a/app/Filament/Resources/ArtistResource.php
+++ b/app/Filament/Resources/ArtistResource.php
@@ -51,7 +51,7 @@ class ArtistResource extends Resource
                                     ->required()
                                     ->maxLength(255)
                                     ->label('Nome da Obra'),
-                                Forms\Components\Textarea::make('description')
+                                Forms\Components\RichEditor::make('description')
                                     ->nullable()
                                     ->label('Descrição da Obra'),
                                 Forms\Components\FileUpload::make('images')


### PR DESCRIPTION
## Summary
- switch the Artwork description field to use Filament's RichEditor

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a3f3399b0832596f2995845739f96