### PR TITLE
Split exhibition description field

### DIFF
--- a/app/Filament/Resources/ExhibitionsResource.php
+++ b/app/Filament/Resources/ExhibitionsResource.php
@@ -136,13 +136,15 @@ class ExhibitionsResource extends Resource
                             ->columns(2)
                             ->schema([
                                 RichEditor::make('description')
-                                    ->label('Descrição da exposição')
-
+                                    ->label('Descrição (PT)')
+                                    ->columnSpan(1),
+                                RichEditor::make('description_en')
+                                    ->label('Description (EN)')
                                     ->columnSpan(1),
                                 RichEditor::make('summary')
                                     ->disableToolbarButtons(['attachFiles'])
                                     ->label('Resumo da exposição')
-                                    ->columnSpan(1),
+                                    ->columnSpan(2),
                                 FileUpload::make('pdf')
                                     ->label('PDF para download')
                                     ->disk('public')

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -20,6 +20,7 @@ class Exhibition extends Model
         'author_name',
         'author_description',
         'description',
+        'description_en',
         'summary',
         'image',
         'banner',

--- a/database/factories/ExhibitionFactory.php
+++ b/database/factories/ExhibitionFactory.php
@@ -33,6 +33,7 @@ class ExhibitionFactory extends Factory
             'author_name' => $this->faker->name(),
             'author_description' => $this->faker->text(100),
             'description' => $this->faker->paragraph(5),
+            'description_en' => $this->faker->paragraph(5),
             'summary' => $this->faker->sentence(10),
             'image' => $imagePath,
             'banner' => $bannerPath,

--- a/database/migrations/2025_09_10_000000_add_description_en_to_exhibitions_table.php
+++ b/database/migrations/2025_09_10_000000_add_description_en_to_exhibitions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('exhibitions', function (Blueprint $table) {
+            $table->longText('description_en')->nullable()->after('description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('exhibitions', function (Blueprint $table) {
+            $table->dropColumn('description_en');
+        });
+    }
+};

--- a/resources/views/exhibition.blade.php
+++ b/resources/views/exhibition.blade.php
@@ -46,9 +46,16 @@
                     @endif
                 </h3>
                 <!-- Conteúdo Principal -->
-                <div class="prose prose-lg max-w-none prose-invert columns-1 md:columns-2 w-full gap-x-10 description text-justify">
-                    {!! $exhibition->description !!}
-                </div>
+               <div class="grid grid-cols-2 gap-2 mt-2">
+
+                   <div class="prose prose-lg max-w-none prose-invert columns-1 w-full gap-x-10 description text-justify border-r px-2">
+                       {!! $exhibition->description !!}
+                   </div>
+
+                   <div class="prose prose-lg max-w-none prose-invert columns-1 w-full gap-x-10 description text-justify">
+                       {!! $exhibition->description_en !!}
+                   </div>
+               </div>
 
                 @if ($exhibition->pdf)
                     <div class="my-6 w-full flex items-center justify-end gap-2">


### PR DESCRIPTION
## Summary
- support English exhibition descriptions
- show PT and EN description fields in Filament admin

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac7d12cb48325898f6207d5a95490