### PR TITLE
Adjust exhibition artworks fields

### DIFF
--- a/app/Filament/Resources/ExhibitionsResource.php
+++ b/app/Filament/Resources/ExhibitionsResource.php
@@ -112,20 +112,17 @@ class ExhibitionsResource extends Resource
                                     ->label('Obras')
                                     ->columnSpan(2)
                                     ->schema([
-                                        TextInput::make('name')
-                                            ->label('Nome da obra')
+                                        RichEditor::make('artist')
+                                            ->label('Artista')
+                                            ->disableToolbarButtons(['attachFiles'])
                                             ->required(),
-                                        TextInput::make('year')
-                                            ->label('Ano')
+                                        RichEditor::make('name')
+                                            ->label('Título da obra')
+                                            ->disableToolbarButtons(['attachFiles'])
                                             ->required(),
-                                        TextInput::make('technique')
-                                            ->label('Técnica')
-                                            ->required(),
-                                        TextInput::make('size_cm')
-                                            ->label('Tamanho (cm)')
-                                            ->required(),
-                                        TextInput::make('description')
+                                        RichEditor::make('description')
                                             ->label('Descrição')
+                                            ->disableToolbarButtons(['attachFiles'])
                                             ->required(),
                                         FileUpload::make('image')
                                             ->label('Imagem da obra')

--- a/resources/views/emails/interesse-exposicao.blade.php
+++ b/resources/views/emails/interesse-exposicao.blade.php
@@ -26,20 +26,14 @@
                     <tr>
                         <td style="padding-top: 24px;">
                             <h3 style="color: #444; margin-bottom: 8px;">Detalhes da Obra</h3>
+                            @if(isset($obra['artist']))
+                                <p><strong>Artista:</strong> {!! $obra['artist'] !!}</p>
+                            @endif
                             @if(isset($obra['name']))
-                                <p><strong>Nome:</strong> {{ $obra['name'] }}</p>
-                            @endif
-                            @if(isset($obra['year']))
-                                <p><strong>Ano:</strong> {{ $obra['year'] }}</p>
-                            @endif
-                            @if(isset($obra['technique']))
-                                <p><strong>Técnica:</strong> {{ $obra['technique'] }}</p>
-                            @endif
-                            @if(isset($obra['size']))
-                                <p><strong>Tamanho:</strong> {{ $obra['size'] }}</p>
+                                <p><strong>Título:</strong> {!! $obra['name'] !!}</p>
                             @endif
                             @if(isset($obra['description']))
-                                <p><strong>Descrição:</strong> {{ $obra['description'] }}</p>
+                                <p><strong>Descrição:</strong> {!! $obra['description'] !!}</p>
                             @endif
                             @if(isset($obra['image']))
                                 <p>

--- a/resources/views/exhibition.blade.php
+++ b/resources/views/exhibition.blade.php
@@ -96,10 +96,9 @@
                                     <img src="{{ asset('storage/' . $item['image']) }}" alt="{{ $item['name'] ?? '' }}"
                                         class="w-full mb-4">
                                     <div class="space-y-1">
-                                        <p class="text-lg  text-gray-900 capitalize">{{ $item['name'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['year'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['technique'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['size_cm'] ?? '' }} cm</p>
+                                        <div class="text-lg text-gray-900 capitalize">{!! $item['artist'] ?? '' !!}</div>
+                                        <div class="text-lg text-gray-900 capitalize">{!! $item['name'] ?? '' !!}</div>
+                                        <div class="text-lg text-gray-700">{!! $item['description'] ?? '' !!}</div>
                                     </div>
                                 </div>
                             @endforeach
@@ -121,13 +120,8 @@
                                 <div
                                     class="flex-1 flex flex-col justify-center items-start md:pl-16 mt-8 md:mt-0 w-full max-w-md transition-all duration-300">
                                     <div class="mb-6">
+                                        <div id="obra-modal-artist" class="text-lg text-black mb-2"></div>
                                         <div id="obra-modal-title" class="text-2xl  text-black mb-4"></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Ano:</span> <span
-                                                id="obra-modal-year"></span></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Técnica:</span>
-                                            <span id="obra-modal-technique"></span></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Tamanho:</span>
-                                            <span id="obra-modal-size"></span></div>
                                         <div id="obra-modal-description" class="text-black text-base mb-6"></div>
                                     </div>
                                     <button id="obra-modal-interest"
@@ -148,10 +142,8 @@
                                     <img id="obra-form-img" src="" alt=""
                                         class="w-24 h-24 object-cover mr-6 border border-gray-300">
                                     <div>
-                                        <div class=" text-black" id="obra-form-title"></div>
-                                        <div class="text-black" id="obra-form-year"></div>
-                                        <div class="text-black" id="obra-form-technique"></div>
-                                        <div class="text-black" id="obra-form-size"></div>
+                                        <div class="text-black" id="obra-form-artist"></div>
+                                        <div class="text-black" id="obra-form-title"></div>
                                         <div class="text-black" id="obra-form-description"></div>
                                     </div>
                                 </div>
@@ -200,10 +192,8 @@
                             const obra = obras[obraModalIdx];
                             document.getElementById('obra-modal-img').src = obra.image ? '/storage/' + obra.image : '';
                             document.getElementById('obra-modal-img').alt = obra.name || '';
+                            document.getElementById('obra-modal-artist').textContent = obra.artist || '';
                             document.getElementById('obra-modal-title').textContent = obra.name || '';
-                            document.getElementById('obra-modal-year').textContent = obra.year || '';
-                            document.getElementById('obra-modal-technique').textContent = obra.technique || '';
-                            document.getElementById('obra-modal-size').textContent = obra.size_cm ? obra.size_cm + ' cm' : '';
                             document.getElementById('obra-modal-description').textContent = obra.description || '';
                         }
                         document.querySelectorAll('.obra-card').forEach((el, idx) => {
@@ -218,12 +208,8 @@
                             const obra = obras[obraModalIdx];
                             document.getElementById('obra-form-img').src = obra.image ? '/storage/' + obra.image : '';
                             document.getElementById('obra-form-img').alt = obra.name || '';
+                            document.getElementById('obra-form-artist').textContent = obra.artist || '';
                             document.getElementById('obra-form-title').textContent = obra.name || '';
-                            document.getElementById('obra-form-year').textContent = obra.year ? 'Ano: ' + obra.year : '';
-                            document.getElementById('obra-form-technique').textContent = obra.technique ? 'Técnica: ' + obra.technique :
-                                '';
-                            document.getElementById('obra-form-size').textContent = obra.size_cm ? 'Tamanho: ' + obra.size_cm + ' cm' :
-                                '';
                             document.getElementById('obra-form-description').textContent = obra.description || '';
                         };
                         document.getElementById('obra-interest-form').onsubmit = function(e) {


### PR DESCRIPTION
## Summary
- simplify repeater fields in exhibitions admin
- display artist, title and description in exhibition view
- update interest email

## Testing
- `composer install`
- `php artisan test` *(fails: no such table: exhibitions)*

------
https://chatgpt.com/codex/tasks/task_e_684acaf1637883259a5c32427d5d13da