### PR TITLE
Add collective artists repeater

### DIFF
--- a/app/Filament/Resources/ExhibitionsResource.php
+++ b/app/Filament/Resources/ExhibitionsResource.php
@@ -53,14 +53,15 @@ class ExhibitionsResource extends Resource
                         Checkbox::make('is_collective')
                             ->label('EXPOSIÇÃO COLETIVA')
                             ->reactive(),
-                        Select::make('photographers')
-                            ->label('Fotógrafos')
-                            ->multiple()
-                            ->preload()
-                            ->relationship('photographers', 'name')
-                            ->createOptionForm([
-                                TextInput::make('name')->label('Nome do fotógrafo')->required(),
+                        Repeater::make('collective_artists')
+                            ->label('Artistas')
+                            ->schema([
+                                TextInput::make('name')->label('Nome')->required(),
+                                TextInput::make('link')->label('Link')->url(),
                             ])
+                            ->columns(2)
+                            ->defaultItems(0)
+                            ->addActionLabel('Adicionar artista')
                             ->visible(fn ($get) => $get('is_collective')),
                         TextInput::make('author_name')
                             ->label('Nome do autor')

--- a/app/Http/Controllers/ExhibitionController.php
+++ b/app/Http/Controllers/ExhibitionController.php
@@ -14,7 +14,7 @@ class ExhibitionController extends Controller
     }
     public function exhibition($slug)
     {
-        $exhibition = \App\Models\Exhibition::with('photographers')->where('slug', $slug)->first();
+        $exhibition = \App\Models\Exhibition::where('slug', $slug)->first();
         return view('exhibition', compact('exhibition'));
     }
 }

--- a/app/Models/Exhibition.php
+++ b/app/Models/Exhibition.php
@@ -28,6 +28,7 @@ class Exhibition extends Model
         'banner_url',
         'gallery',
         'pdf',
+        'collective_artists',
         'is_collective',
         'banner_position',
         'year',
@@ -40,6 +41,7 @@ class Exhibition extends Model
         'start_date' => 'date',
         'end_date' => 'date',
         'gallery' => 'array',
+        'collective_artists' => 'array',
     ];
 
     public function photographers()

--- a/database/migrations/2025_09_11_000001_add_collective_artists_to_exhibitions_table.php
+++ b/database/migrations/2025_09_11_000001_add_collective_artists_to_exhibitions_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('exhibitions', function (Blueprint $table) {
+            $table->json('collective_artists')->nullable()->after('is_collective');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('exhibitions', function (Blueprint $table) {
+            $table->dropColumn('collective_artists');
+        });
+    }
+};

--- a/resources/views/exhibition.blade.php
+++ b/resources/views/exhibition.blade.php
@@ -45,9 +45,11 @@
         <div class="w-full gap-14">
             <div class="w-full">
                 <h3 class="text-2xl md:text-3xl font-medium text-black {{$exhibition->is_collective ? 'text-center mb-4' : ''}}">
-                    @if ($exhibition->is_collective && $exhibition->photographers && $exhibition->photographers->count())
-                        {!! $exhibition->photographers->map(function($photographer) {
-                            return '<a href="' . route('artists.show', $photographer->id) . '" class="hover:underline font-medium">' . e($photographer->name) . '</a>';
+                    @if ($exhibition->is_collective && $exhibition->collective_artists)
+                        {!! collect($exhibition->collective_artists)->map(function ($artist) {
+                            $name = e($artist['name'] ?? '');
+                            $link = $artist['link'] ?? null;
+                            return $link ? '<a href="' . e($link) . '" class="hover:underline font-medium">' . $name . '</a>' : $name;
                         })->implode(' - ') !!}
                     @else
                         @if ($exhibition->artist)


### PR DESCRIPTION
## Summary
- allow exhibitions to store a list of collective artists
- show collective artists links on the exhibition page
- adjust exhibition controller and model
- replace photographers select with repeater in Filament

## Testing
- `php artisan test --testsuite=Feature --stop-on-failure` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9df21f8c8325a53f9f183893587b