### PR TITLE
Enable artworks order change

### DIFF
--- a/app/Filament/Resources/ArtistResource.php
+++ b/app/Filament/Resources/ArtistResource.php
@@ -46,11 +46,15 @@ class ArtistResource extends Resource
                     ->schema([
                         Forms\Components\Repeater::make('artworks')
                             ->relationship()
+                            ->itemLabel(fn (array $state): ?string => $state['name'] ?? 'Nova Obra')
                             ->schema([
                                 Forms\Components\TextInput::make('name')
                                     ->required()
                                     ->maxLength(255)
                                     ->label('Nome da Obra'),
+                                Forms\Components\Toggle::make('featured')
+                                    ->label('Destaque')
+                                    ->default(false),
                                 Forms\Components\RichEditor::make('description')
                                     ->nullable()
                                     ->label('Descrição da Obra'),
@@ -60,9 +64,6 @@ class ArtistResource extends Resource
                                     ->directory('artworks')
                                     ->maxSize(5120)
                                     ->label('Imagens da Obra'),
-                                Forms\Components\Toggle::make('featured')
-                                    ->label('Destaque')
-                                    ->default(false),
                                 Forms\Components\TextInput::make('order')
                                     ->numeric()
                                     ->default(0)

--- a/app/Filament/Resources/ArtistResource.php
+++ b/app/Filament/Resources/ArtistResource.php
@@ -70,7 +70,7 @@ class ArtistResource extends Resource
                             ])
                             ->columns(2)
                             ->defaultItems(1)
-                            ->reorderable('order')
+                            ->orderColumn('order')
                             ->collapsible()
                             ->cloneable()
                             ->label('Obras do Artista')


### PR DESCRIPTION
## Summary
- ensure the Artist resource uses `orderColumn()` so artworks can be reordered in forms

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ca08261648325bc8a2327977bc591