### PR TITLE
Simplify artwork fields for exhibitions

### DIFF
--- a/app/Filament/Resources/ExhibitionsResource.php
+++ b/app/Filament/Resources/ExhibitionsResource.php
@@ -116,18 +116,13 @@ class ExhibitionsResource extends Resource
                                         TextInput::make('name')
                                             ->label('Nome da obra')
                                             ->required(),
-                                        TextInput::make('year')
-                                            ->label('Ano')
+                                        TextInput::make('artist')
+                                            ->label('Nome do artista')
                                             ->required(),
-                                        TextInput::make('technique')
-                                            ->label('Técnica')
-                                            ->required(),
-                                        TextInput::make('size_cm')
-                                            ->label('Tamanho (cm)')
-                                            ->required(),
-                                        TextInput::make('description')
+                                        RichEditor::make('description')
                                             ->label('Descrição')
-                                            ->required(),
+                                            ->disableToolbarButtons(['attachFiles'])
+                                            ->columnSpan(2),
                                         FileUpload::make('image')
                                             ->label('Imagem da obra')
                                             ->image()

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -16,6 +16,7 @@ class Artist extends Model
         'name',
         'description',
         'image',
+        'order'
     ];
 
     protected $casts = [

--- a/resources/views/emails/interesse-exposicao.blade.php
+++ b/resources/views/emails/interesse-exposicao.blade.php
@@ -29,17 +29,11 @@
                             @if(isset($obra['name']))
                                 <p><strong>Nome:</strong> {{ $obra['name'] }}</p>
                             @endif
-                            @if(isset($obra['year']))
-                                <p><strong>Ano:</strong> {{ $obra['year'] }}</p>
-                            @endif
-                            @if(isset($obra['technique']))
-                                <p><strong>Técnica:</strong> {{ $obra['technique'] }}</p>
-                            @endif
-                            @if(isset($obra['size']))
-                                <p><strong>Tamanho:</strong> {{ $obra['size'] }}</p>
+                            @if(isset($obra['artist']))
+                                <p><strong>Artista:</strong> {{ $obra['artist'] }}</p>
                             @endif
                             @if(isset($obra['description']))
-                                <p><strong>Descrição:</strong> {{ $obra['description'] }}</p>
+                                <p><strong>Descrição:</strong> {!! $obra['description'] !!}</p>
                             @endif
                             @if(isset($obra['image']))
                                 <p>

--- a/resources/views/exhibition.blade.php
+++ b/resources/views/exhibition.blade.php
@@ -99,9 +99,7 @@
                                         class="w-full mb-4">
                                     <div class="space-y-1">
                                         <p class="text-lg  text-gray-900 capitalize">{{ $item['name'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['year'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['technique'] ?? '' }}</p>
-                                        <p class="text-lg text-gray-700 capitalize">{{ $item['size_cm'] ?? '' }} cm</p>
+                                        <p class="text-lg text-gray-700 capitalize">{{ $item['artist'] ?? '' }}</p>
                                     </div>
                                 </div>
                             @endforeach
@@ -124,12 +122,9 @@
                                     class="flex-1 flex flex-col justify-center items-start md:pl-16 mt-8 md:mt-0 w-full max-w-md transition-all duration-300">
                                     <div class="mb-6">
                                         <div id="obra-modal-title" class="text-2xl  text-black mb-4"></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Ano:</span> <span
-                                                id="obra-modal-year"></span></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Técnica:</span>
-                                            <span id="obra-modal-technique"></span></div>
-                                        <div class="text-lg text-black mb-2"><span class="">Tamanho:</span>
-                                            <span id="obra-modal-size"></span></div>
+                                        <div class="text-lg text-black mb-2">
+                                            <span id="obra-modal-artist"></span>
+                                        </div>
                                         <div id="obra-modal-description" class="text-black text-base mb-6"></div>
                                     </div>
                                     <button id="obra-modal-interest"
@@ -151,9 +146,7 @@
                                         class="w-24 h-24 object-cover mr-6 border border-gray-300">
                                     <div>
                                         <div class=" text-black" id="obra-form-title"></div>
-                                        <div class="text-black" id="obra-form-year"></div>
-                                        <div class="text-black" id="obra-form-technique"></div>
-                                        <div class="text-black" id="obra-form-size"></div>
+                                        <div class="text-black" id="obra-form-artist"></div>
                                         <div class="text-black" id="obra-form-description"></div>
                                     </div>
                                 </div>
@@ -203,10 +196,8 @@
                             document.getElementById('obra-modal-img').src = obra.image ? '/storage/' + obra.image : '';
                             document.getElementById('obra-modal-img').alt = obra.name || '';
                             document.getElementById('obra-modal-title').textContent = obra.name || '';
-                            document.getElementById('obra-modal-year').textContent = obra.year || '';
-                            document.getElementById('obra-modal-technique').textContent = obra.technique || '';
-                            document.getElementById('obra-modal-size').textContent = obra.size_cm ? obra.size_cm + ' cm' : '';
-                            document.getElementById('obra-modal-description').textContent = obra.description || '';
+                            document.getElementById('obra-modal-artist').textContent = obra.artist || '';
+                            document.getElementById('obra-modal-description').innerHTML = obra.description || '';
                         }
                         document.querySelectorAll('.obra-card').forEach((el, idx) => {
                             el.onclick = function() {
@@ -221,12 +212,8 @@
                             document.getElementById('obra-form-img').src = obra.image ? '/storage/' + obra.image : '';
                             document.getElementById('obra-form-img').alt = obra.name || '';
                             document.getElementById('obra-form-title').textContent = obra.name || '';
-                            document.getElementById('obra-form-year').textContent = obra.year ? 'Ano: ' + obra.year : '';
-                            document.getElementById('obra-form-technique').textContent = obra.technique ? 'Técnica: ' + obra.technique :
-                                '';
-                            document.getElementById('obra-form-size').textContent = obra.size_cm ? 'Tamanho: ' + obra.size_cm + ' cm' :
-                                '';
-                            document.getElementById('obra-form-description').textContent = obra.description || '';
+                            document.getElementById('obra-form-artist').textContent = obra.artist ? obra.artist : '';
+                            document.getElementById('obra-form-description').innerHTML = obra.description || '';
                         };
                         document.getElementById('obra-interest-form').onsubmit = function(e) {
                             // Submissão normal do formulário
@@ -271,10 +258,8 @@
                                      class="w-full aspect-[4/3] object-cover rounded-xl transition-transform duration-300 group-hover:scale-[1.02] mb-4">
                                 <div class="space-y-1">
                                     <p class="text-lg  text-gray-900">{{ $item['name'] ?? '' }}</p>
-                                    <p class="text-sm text-gray-700">Ano: {{ $item['year'] ?? '' }}</p>
-                                    <p class="text-sm text-gray-700">Técnica: {{ $item['technique'] ?? '' }}</p>
-                                    <p class="text-sm text-gray-700">Tamanho: {{ $item['size_cm'] ?? '' }} cm</p>
-                                    <p class="text-sm text-gray-700">{{ $item['description'] ?? '' }}</p>
+                                    <p class="text-sm text-gray-700">{{ $item['artist'] ?? '' }}</p>
+                                    <p class="text-sm text-gray-700">{!! $item['description'] ?? '' !!}</p>
                                     </div>
                             </div>
                         @endforeach


### PR DESCRIPTION
## Summary
- update Exhibition Filament resource to simplify artwork fields
- adjust exhibition view and modal scripts for new fields
- tweak interest email template for new artwork data

## Testing
- `phpunit` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ca300c5508325955fa0986bc0c542