### PR TITLE
Implementa destaque de notícias, ordenação por arrastar no acervo e e-mail da equipe

### DIFF
--- a/app/Filament/Resources/ArtistResource.php
+++ b/app/Filament/Resources/ArtistResource.php
@@ -32,6 +32,11 @@ class ArtistResource extends Resource
                     ->columnSpanFull()
                     ->maxLength(255)
                     ->label('Nome'),
+                Forms\Components\Toggle::make('is_represented')
+                    ->label('Representado pela galeria')
+                    ->helperText('Artistas representados aparecem em destaque na lista')
+                    ->default(false)
+                    ->columnSpanFull(),
                 Forms\Components\RichEditor::make('description')
                     ->label('Descrição')
                     ->nullable()
@@ -76,7 +81,63 @@ class ArtistResource extends Resource
                             ->cloneable()
                             ->label('Obras do Artista')
                     ])
+                    ->collapsible(),
+                Forms\Components\Section::make('Projetos')
+                    ->schema([
+                        Forms\Components\Repeater::make('projects')
+                            ->relationship()
+                            ->itemLabel(fn (array $state): ?string => $state['name'] ?? 'Novo Projeto')
+                            ->schema([
+                                Forms\Components\Hidden::make('order'),
+                                Forms\Components\TextInput::make('name')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->label('Nome do Projeto'),
+                                Forms\Components\RichEditor::make('description')
+                                    ->nullable()
+                                    ->label('Descrição do Projeto')
+                                    ->columnSpanFull(),
+                                Forms\Components\Repeater::make('artworks')
+                                    ->relationship()
+                                    ->itemLabel(fn (array $state): ?string => $state['name'] ?? 'Nova Obra')
+                                    ->schema([
+                                        Forms\Components\Hidden::make('order'),
+                                        Forms\Components\TextInput::make('name')
+                                            ->required()
+                                            ->maxLength(255)
+                                            ->label('Nome da Obra'),
+                                        Forms\Components\Toggle::make('featured')
+                                            ->label('Destaque')
+                                            ->default(false),
+                                        Forms\Components\RichEditor::make('description')
+                                            ->nullable()
+                                            ->label('Descrição da Obra'),
+                                        Forms\Components\FileUpload::make('images')
+                                            ->image()
+                                            ->multiple()
+                                            ->directory('artworks')
+                                            ->maxSize(5120)
+                                            ->label('Imagens da Obra'),
+                                    ])
+                                    ->columns(2)
+                                    ->defaultItems(0)
+                                    ->orderColumn('order')
+                                    ->reorderable()
+                                    ->collapsible()
+                                    ->cloneable()
+                                    ->label('Obras do Projeto')
+                                    ->columnSpanFull(),
+                            ])
+                            ->columns(2)
+                            ->defaultItems(0)
+                            ->orderColumn('order')
+                            ->reorderable()
+                            ->collapsible()
+                            ->cloneable()
+                            ->label('Projetos do Artista')
+                    ])
                     ->collapsible()
+                    ->collapsed()
             ]);
     }
 
@@ -85,7 +146,11 @@ class ArtistResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('name')
-                    ->searchable(),
+                    ->searchable()
+                    ->label('Nome'),
+                Tables\Columns\IconColumn::make('is_represented')
+                    ->boolean()
+                    ->label('Representado'),
                 Tables\Columns\TextColumn::make('deleted_at')
                     ->dateTime()
                     ->sortable()

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -42,17 +42,14 @@ class CollectionResource extends Resource
                     ->image()
                     ->directory('acervo')
                     ->required(),
-                Forms\Components\TextInput::make('order')
-                    ->label('Ordem')
-                    ->numeric()
-                    ->default(0)
-                    ->helperText('Número para ordenação (menor = primeiro)'),
             ]);
     }
 
     public static function table(Table $table): Table
     {
         return $table
+            ->reorderable('order')
+            ->defaultSort('order')
             ->columns([
                 Tables\Columns\ImageColumn::make('image')
                     ->label('Imagem')
@@ -68,7 +65,6 @@ class CollectionResource extends Resource
                     ->label('Ordem')
                     ->sortable(),
             ])
-            ->defaultSort('order')
             ->filters([
                 //
             ])

--- a/app/Filament/Resources/NoticiesResource.php
+++ b/app/Filament/Resources/NoticiesResource.php
@@ -6,7 +6,6 @@ use App\Filament\Resources\NoticiesResource\Pages;
 use App\Models\Noticies;
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Forms\Components\DatePicker;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -45,6 +44,10 @@ class NoticiesResource extends Resource
                 Forms\Components\DatePicker::make('date')
                     ->label('Data')
                     ->columns(1),
+                Forms\Components\Toggle::make('is_pinned')
+                    ->label('Fixar no topo')
+                    ->helperText('Notícias fixadas aparecem primeiro na página de notícias.')
+                    ->default(false),
                 Forms\Components\TextInput::make('author_name')
                     ->label('Autor')
                     ->columns(1)
@@ -64,7 +67,12 @@ class NoticiesResource extends Resource
     public static function table(Table $table): Table
     {
         return $table
+            ->reorderable('sort_order')
+            ->defaultSort('sort_order')
             ->columns([
+                Tables\Columns\IconColumn::make('is_pinned')
+                    ->label('Fixada')
+                    ->boolean(),
                 Tables\Columns\TextColumn::make('title')
                     ->label('Título')
                     ->searchable(),
@@ -79,6 +87,9 @@ class NoticiesResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('image_url')
                     ->label('URL da Imagem'),
+                Tables\Columns\TextColumn::make('sort_order')
+                    ->label('Ordem')
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('deleted_at')
                     ->dateTime()
                     ->sortable()
@@ -92,7 +103,6 @@ class NoticiesResource extends Resource
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
-            ->defaultSort('date', 'desc')
             ->filters([
                 //
             ])

--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -3,15 +3,12 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\TeamResource\Pages;
-use App\Filament\Resources\TeamResource\RelationManagers;
 use App\Models\Team;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
 
 class TeamResource extends Resource
 {
@@ -35,6 +32,10 @@ class TeamResource extends Resource
                     ->label('Função')
                     ->required()
                     ->maxLength(255),
+                Forms\Components\TextInput::make('email')
+                    ->label('E-mail de Contato')
+                    ->email()
+                    ->maxLength(255),
             ]);
     }
 
@@ -48,6 +49,11 @@ class TeamResource extends Resource
                 Tables\Columns\TextColumn::make('function')
                     ->label('Função')
                     ->searchable(),
+                Tables\Columns\TextColumn::make('email')
+                    ->label('E-mail')
+                    ->searchable()
+                    ->copyable()
+                    ->placeholder('-'),
             ])
             ->filters([
                 //

--- a/app/Http/Controllers/ArtistController.php
+++ b/app/Http/Controllers/ArtistController.php
@@ -19,9 +19,17 @@ class ArtistController extends Controller
 
     public function show($id)
     {
-        $artist = Artist::with(['artworks' => function ($query) {
-            $query->orderByDesc('featured')->orderBy('order');
-        }])->findOrFail($id);
+        $artist = Artist::with([
+            'artworks' => function ($query) {
+                $query->orderByDesc('featured')->orderBy('order');
+            },
+            'projects' => function ($query) {
+                $query->orderBy('order');
+            },
+            'projects.artworks' => function ($query) {
+                $query->orderByDesc('featured')->orderBy('order');
+            }
+        ])->findOrFail($id);
         return view('artists.show', compact('artist'));
     }
 

--- a/app/Http/Controllers/NoticieController.php
+++ b/app/Http/Controllers/NoticieController.php
@@ -8,7 +8,11 @@ class NoticieController extends Controller
 {
     public function index()
     {
-        $noticies = Noticies::orderByDesc('date')->get();
+        $noticies = Noticies::query()
+            ->orderByDesc('is_pinned')
+            ->orderBy('sort_order')
+            ->orderByDesc('date')
+            ->get();
         return view('noticies', compact('noticies'));
     }
 

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -15,11 +15,13 @@ class Artist extends Model
     protected $fillable = [
         'name',
         'description',
-        'image'
+        'image',
+        'is_represented',
     ];
 
     protected $casts = [
         'image' => 'array',
+        'is_represented' => 'boolean',
     ];
 
     public function artworks()
@@ -27,5 +29,10 @@ class Artist extends Model
         return $this->hasMany(Artwork::class)
             ->orderByDesc('featured')
             ->orderBy('order');
+    }
+
+    public function projects()
+    {
+        return $this->hasMany(Project::class)->orderBy('order');
     }
 }

--- a/app/Models/Artwork.php
+++ b/app/Models/Artwork.php
@@ -10,8 +10,18 @@ class Artwork extends Model
 {
     use HasFactory, SoftDeletes;
 
+    protected static function booted()
+    {
+        static::creating(function ($artwork) {
+            if ($artwork->project_id && !$artwork->artist_id) {
+                $artwork->artist_id = $artwork->project->artist_id;
+            }
+        });
+    }
+
     protected $fillable = [
         'artist_id',
+        'project_id',
         'name',
         'description',
         'images',
@@ -31,5 +41,10 @@ class Artwork extends Model
     public function artist()
     {
         return $this->belongsTo(Artist::class);
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
     }
 }

--- a/app/Models/Noticies.php
+++ b/app/Models/Noticies.php
@@ -15,11 +15,14 @@ class Noticies extends Model
         'image_url',
         'summary',
         'is_active',
+        'is_pinned',
+        'sort_order',
         'url',
         'date',
     ];
     protected $casts = [
         'is_active' => 'boolean',
+        'is_pinned' => 'boolean',
         'date' => 'date',
     ];
     protected $dates = [

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Project extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'artist_id',
+        'name',
+        'description',
+        'order',
+    ];
+
+    protected $casts = [
+        'order' => 'integer',
+    ];
+
+    public function artist()
+    {
+        return $this->belongsTo(Artist::class);
+    }
+
+    public function artworks()
+    {
+        return $this->hasMany(Artwork::class)->orderBy('order');
+    }
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -9,5 +9,6 @@ class Team extends Model
     protected $fillable = [
         'name',
         'function',
+        'email',
     ];
 }

--- a/database/migrations/2026_02_10_000001_add_pinning_and_sort_order_to_noticies_table.php
+++ b/database/migrations/2026_02_10_000001_add_pinning_and_sort_order_to_noticies_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('noticies', function (Blueprint $table) {
+            if (! Schema::hasColumn('noticies', 'is_pinned')) {
+                $table->boolean('is_pinned')->default(false)->after('is_active');
+            }
+
+            if (! Schema::hasColumn('noticies', 'sort_order')) {
+                $table->unsignedInteger('sort_order')->default(0)->after('is_pinned');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('noticies', function (Blueprint $table) {
+            if (Schema::hasColumn('noticies', 'sort_order')) {
+                $table->dropColumn('sort_order');
+            }
+
+            if (Schema::hasColumn('noticies', 'is_pinned')) {
+                $table->dropColumn('is_pinned');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_02_10_000002_add_email_to_teams_table.php
+++ b/database/migrations/2026_02_10_000002_add_email_to_teams_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            if (! Schema::hasColumn('teams', 'email')) {
+                $table->string('email')->nullable()->after('function');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            if (Schema::hasColumn('teams', 'email')) {
+                $table->dropColumn('email');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_02_12_232552_add_is_represented_to_artists_table.php
+++ b/database/migrations/2026_02_12_232552_add_is_represented_to_artists_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->boolean('is_represented')->default(false)->after('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('artists', function (Blueprint $table) {
+            $table->dropColumn('is_represented');
+        });
+    }
+};

--- a/database/migrations/2026_02_12_232656_create_projects_table.php
+++ b/database/migrations/2026_02_12_232656_create_projects_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('artist_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->integer('order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::table('artworks', function (Blueprint $table) {
+            $table->foreignId('project_id')->nullable()->after('artist_id')->constrained()->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('artworks', function (Blueprint $table) {
+            $table->dropForeign(['project_id']);
+            $table->dropColumn('project_id');
+        });
+        Schema::dropIfExists('projects');
+    }
+};

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -15,12 +15,12 @@
                 </div>
                 <ul id="artist-list" class="hidden lg:block">
                     @foreach ($artists as $artist)
-                        <li class="cursor-pointer text-xl p-2 text-gray-400 uppercase tracking-wide" data-id="{{ $artist->id }}">
+                        <li class="cursor-pointer text-xl p-2 uppercase tracking-wide {{ $artist->is_represented ? 'text-gray-600 font-semibold' : 'text-gray-400' }}"
+                            data-id="{{ $artist->id }}"
+                            data-represented="{{ $artist->is_represented ? '1' : '0' }}">
                             {{ $artist->name }}
                         </li>
                     @endforeach
-
-
                 </ul>
             </div>
             <div class="w-full text-gray-950 text-xl lg:sticky lg:top-4 lg:self-start">
@@ -59,8 +59,8 @@
                         let firstArtist = document.querySelector("#artist-list li");
                         if (firstArtist) {
                             let firstArtistId = firstArtist.getAttribute("data-id");
-                            firstArtist.classList.remove("text-gray-400");
-                            firstArtist.classList.add("text-gray-950");
+                            firstArtist.classList.remove("text-gray-400", "text-gray-600", "font-semibold");
+                            firstArtist.classList.add("text-gray-950", "font-bold");
                             selectArtist(firstArtistId);
                         }
                     }
@@ -90,13 +90,19 @@
                         currentImages = data.images || [];
                         currentIndex = 0;
                         document.querySelectorAll("#artist-list li").forEach(li => {
-                            li.classList.remove("text-gray-950");
-                            li.classList.add("text-gray-400");
+                            li.classList.remove("text-gray-950", "font-bold");
+                            const isRepresented = li.getAttribute('data-represented') === '1';
+                            if (isRepresented) {
+                                li.classList.add("text-gray-600", "font-semibold");
+                            } else {
+                                li.classList.add("text-gray-400");
+                                li.classList.remove("font-semibold");
+                            }
                         });
                         let selectedArtist = document.querySelector(`[data-id='${artistId}']`);
                         if (selectedArtist) {
-                            selectedArtist.classList.remove("text-gray-400");
-                            selectedArtist.classList.add("text-gray-950");
+                            selectedArtist.classList.remove("text-gray-400", "text-gray-600", "font-semibold");
+                            selectedArtist.classList.add("text-gray-950", "font-bold");
                         }
                         renderCarousel();
                     });

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -6,14 +6,19 @@
             <div class="md:grid md:grid-cols-[400px_1fr] md:items-start w-full flex flex-col items-center gap-2">
                 <h1 class="md:text-3xl text-2xl my-2 text-gray-950 font-light mb-2">{{ $artist->name }}</h1>
                 <div class="">
-                    @if ($artist->artworks->count() > 0)
+                    @php
+                        $mainArtworks = $artist->artworks->whereNull('project_id');
+                        $projects = $artist->projects;
+                        $hasProjects = $projects->count() > 0;
+                    @endphp
+                    @if ($artist->artworks->count() > 0 || $hasProjects)
                         @php
-                            $destaque = $artist->artworks->first();
-                            $outras = $artist->artworks->slice(1);
-                            $allArtworks = $artist->artworks->values();
+                            $destaque = $mainArtworks->first();
+                            $outras = $mainArtworks->slice(1);
+                            $allArtworks = $mainArtworks->values();
                         @endphp
+                        @if($destaque)
                         <div class="flex flex-col items-center mb-12">
-
                             <div class="w-full max-w-xl mx-auto mb-8">
                                 @if (is_array($destaque->images) && count($destaque->images) > 0)
                                     <img src="{{ asset('storage/' . $destaque->images[0]) }}"
@@ -21,14 +26,13 @@
                                          class="w-full h-[500px] object-contain mx-auto cursor-pointer"
                                          onclick="openArtworkModal(0)">
                                 @else
-                                    <div
-                                        class="w-full aspect-square flex items-center justify-center bg-gray-200 rounded-lg">
+                                    <div class="w-full aspect-square flex items-center justify-center bg-gray-200 rounded-lg">
                                         <span class="text-gray-400 text-7xl">{{ substr($destaque->name, 0, 1) }}</span>
                                     </div>
                                 @endif
                             </div>
-
                         </div>
+                        @endif
                         <!-- Modal navegável -->
                         <div id="artwork-modal"
                              style="display:none; position:fixed; top:0; left:0; width:100vw; height:100vh; background:rgba(0,0,0,0.85); z-index:9999; align-items:center; justify-content:center;">
@@ -84,6 +88,8 @@
                                     @csrf
                                     <input type="hidden" name="artist_id" value="{{ $artist->id }}">
                                     <input type="hidden" name="obra_index" id="artist-obra-index" value="">
+                                    <input type="hidden" name="artwork_id" id="artwork-id" value="">
+                                    <input type="hidden" name="artwork_name" id="artwork-name" value="">
                                     <button type="button" onclick="closeArtworkModal()"
                                             style="position:absolute; top:32px; right:32px; font-size:3rem; color:black; background:none; border:none; cursor:pointer; z-index:10;">
                                         &times;
@@ -219,31 +225,74 @@
                 </div>
             </div>
 
-            <div class="w-full flex items-center justify-center my-5">
-                <span class="text-gray-600 text-base text-left w-full max-w-[200px]">OBRAS EM DESTAQUE</span>
+            <div class="w-full flex items-center my-5 gap-4">
+                <button class="project-tab text-gray-950 font-semibold text-base text-left whitespace-nowrap" data-project="main">OBRAS EM DESTAQUE</button>
                 <div class="h-[1px] bg-[#D1D1D1] w-full"></div>
-            </div>
-            @if ($outras->count() > 0)
-                <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-                    @foreach ($artist->artworks as $i => $artwork)
-                        @continue($i === 0)
-                        <div class="flex flex-col items-center">
-                            <div class="w-full mb-2 flex items-center justify-center p-2">
-                                @if (is_array($artwork->images) && count($artwork->images) > 0)
-                                    <img src="{{ asset('storage/' . $artwork->images[0]) }}"
-                                         alt="{{ $artwork->name }}"
-                                         class="max-w-full max-h-[200px] object-contain cursor-pointer"
-                                         onclick="openArtworkModal({{ $i }})">
-                                @else
-                                    <div class="w-full h-32 flex items-center justify-center">
-                                                    <span
-                                                        class="text-gray-400 text-4xl">{{ substr($artwork->name, 0, 1) }}</span>
-                                    </div>
-                                @endif
-                            </div>
-                        </div>
+                @if($hasProjects)
+                    @foreach($projects as $project)
+                        <button class="project-tab text-gray-400 text-base whitespace-nowrap hover:text-gray-600" data-project="{{ $project->id }}">{{ strtoupper($project->name) }}</button>
                     @endforeach
+                @endif
+            </div>
+
+            {{-- Obras em Destaque --}}
+            <div id="content-main" class="project-content">
+                @if ($outras->count() > 0)
+                    <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+                        @foreach ($mainArtworks as $i => $artwork)
+                            @continue($loop->first)
+                            <div class="flex flex-col items-center">
+                                <div class="w-full mb-2 flex items-center justify-center p-2">
+                                    @if (is_array($artwork->images) && count($artwork->images) > 0)
+                                        <img src="{{ asset('storage/' . $artwork->images[0]) }}"
+                                             alt="{{ $artwork->name }}"
+                                             class="max-w-full max-h-[200px] object-contain cursor-pointer"
+                                             onclick="openArtworkModal({{ $loop->index }})">
+                                    @else
+                                        <div class="w-full h-32 flex items-center justify-center">
+                                            <span class="text-gray-400 text-4xl">{{ substr($artwork->name, 0, 1) }}</span>
+                                        </div>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <p class="text-gray-400 text-center py-8">Nenhuma obra em destaque.</p>
+                @endif
+            </div>
+
+            {{-- Conteúdo dos Projetos --}}
+            @if($hasProjects)
+                @foreach($projects as $project)
+                <div id="content-{{ $project->id }}" class="project-content" style="display:none;">
+                    @if($project->description)
+                    <div class="mb-6 text-gray-700 text-base">{!! $project->description !!}</div>
+                    @endif
+                    @if($project->artworks->count() > 0)
+                        <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+                            @foreach ($project->artworks as $artwork)
+                                <div class="flex flex-col items-center">
+                                    <div class="w-full mb-2 flex items-center justify-center p-2">
+                                        @if (is_array($artwork->images) && count($artwork->images) > 0)
+                                            <img src="{{ asset('storage/' . $artwork->images[0]) }}"
+                                                 alt="{{ $artwork->name }}"
+                                                 class="max-w-full max-h-[200px] object-contain cursor-pointer"
+                                                 onclick="openProjectModal('{{ $project->id }}', {{ $loop->index }})">
+                                        @else
+                                            <div class="w-full h-32 flex items-center justify-center">
+                                                <span class="text-gray-400 text-4xl">{{ substr($artwork->name, 0, 1) }}</span>
+                                            </div>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @else
+                        <p class="text-gray-400 text-center py-8">Nenhuma obra neste projeto.</p>
+                    @endif
                 </div>
+                @endforeach
             @endif
 
             @if ($artist->description)
@@ -291,4 +340,121 @@
     <div class="pt-6 container-kobbi flex items-center justify-center">
         <livewire:newsletter-form />
     </div>
+
+    @if($hasProjects)
+    <script>
+        // Dados dos projetos
+        const projectsData = {
+            @foreach($projects as $project)
+            '{{ $project->id }}': @json($project->artworks->values()),
+            @endforeach
+        };
+
+        let currentProjectId = null;
+        let currentProjectIdx = 0;
+
+        // Controle das abas
+        document.querySelectorAll('.project-tab').forEach(tab => {
+            tab.addEventListener('click', function() {
+                const projectId = this.getAttribute('data-project');
+
+                // Atualiza estilos das abas
+                document.querySelectorAll('.project-tab').forEach(t => {
+                    t.classList.remove('text-gray-950', 'font-semibold');
+                    t.classList.add('text-gray-400');
+                });
+                this.classList.remove('text-gray-400');
+                this.classList.add('text-gray-950', 'font-semibold');
+
+                // Mostra/esconde conteúdo
+                document.querySelectorAll('.project-content').forEach(content => {
+                    content.style.display = 'none';
+                });
+                document.getElementById('content-' + projectId).style.display = 'block';
+            });
+        });
+
+        // Modal para projetos
+        function openProjectModal(projectId, idx) {
+            currentProjectId = projectId;
+            currentProjectIdx = idx;
+            renderProjectModal();
+            document.getElementById('artwork-modal').style.display = 'flex';
+        }
+
+        function renderProjectModal() {
+            const projectArtworks = projectsData[currentProjectId];
+            const artwork = projectArtworks[currentProjectIdx];
+            document.getElementById('artwork-modal-img').src = artwork.images && artwork.images.length > 0 ? '/storage/' + artwork.images[0] : '';
+            document.getElementById('artwork-modal-img').alt = artwork.name || '';
+            document.getElementById('artwork-modal-artist').textContent = '{{ $artist->name }}';
+            document.getElementById('artwork-modal-title').textContent = artwork.name || '';
+            document.getElementById('artwork-modal-desc').innerHTML = artwork.description || '';
+            document.getElementById('artwork-modal-description').innerHTML = artwork.technical_details || '';
+            document.getElementById('modal-prev').style.visibility = currentProjectIdx > 0 ? 'visible' : 'hidden';
+            document.getElementById('modal-next').style.visibility = currentProjectIdx < projectArtworks.length - 1 ? 'visible' : 'hidden';
+
+            // Atualiza dados para o formulário de interesse
+            document.getElementById('artist-obra-index').value = 'project-' + currentProjectId + '-' + currentProjectIdx;
+        }
+
+        // Sobrescreve os handlers de navegação quando está em modo projeto
+        const originalPrevClick = document.getElementById('modal-prev').onclick;
+        const originalNextClick = document.getElementById('modal-next').onclick;
+        const originalInterestClick = document.getElementById('modal-interest').onclick;
+
+        document.getElementById('modal-prev').onclick = function() {
+            if (currentProjectId !== null) {
+                if (currentProjectIdx > 0) {
+                    currentProjectIdx--;
+                    renderProjectModal();
+                }
+            } else {
+                originalPrevClick.call(this);
+            }
+        };
+
+        document.getElementById('modal-next').onclick = function() {
+            if (currentProjectId !== null) {
+                const projectArtworks = projectsData[currentProjectId];
+                if (currentProjectIdx < projectArtworks.length - 1) {
+                    currentProjectIdx++;
+                    renderProjectModal();
+                }
+            } else {
+                originalNextClick.call(this);
+            }
+        };
+
+        document.getElementById('modal-interest').onclick = function() {
+            document.getElementById('modal-content').style.display = 'none';
+            document.getElementById('interest-form').style.display = 'flex';
+
+            let artwork;
+            if (currentProjectId !== null) {
+                const projectArtworks = projectsData[currentProjectId];
+                artwork = projectArtworks[currentProjectIdx];
+            } else {
+                artwork = artworks[currentModalIdx];
+            }
+
+            document.getElementById('form-artwork-img').src = artwork.images && artwork.images.length > 0 ? '/storage/' + artwork.images[0] : '';
+            document.getElementById('form-artwork-img').alt = artwork.name || '';
+            document.getElementById('form-artwork-artist').textContent = '{{ $artist->name }}';
+            document.getElementById('form-artwork-title').textContent = artwork.name || '';
+            document.getElementById('form-artwork-desc').innerHTML = artwork.description || '';
+
+            // Preenche campos hidden com dados da obra
+            document.getElementById('artwork-id').value = artwork.id || '';
+            document.getElementById('artwork-name').value = artwork.name || '';
+        };
+
+        // Reset currentProjectId quando abre modal de obras principais
+        const originalOpenArtworkModal = window.openArtworkModal;
+        window.openArtworkModal = function(idx) {
+            currentProjectId = null;
+            originalOpenArtworkModal(idx);
+        };
+    </script>
+    @endif
 @endsection

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -83,6 +83,11 @@
                     <div class="mb-6">
                         <div class="text-gray-950 text-base font-medium tracking-wide uppercase mb-2">{{ $member->function }}</div>
                         <div class="text-gray-700 text-base">{{ $member->name }}</div>
+                        @if($member->email)
+                            <div class="text-gray-700 text-sm mt-1">
+                                <a href="mailto:{{ $member->email }}" class="hover:underline">{{ $member->email }}</a>
+                            </div>
+                        @endif
                     </div>
                 @endforeach
             </div>

--- a/resources/views/noticies.blade.php
+++ b/resources/views/noticies.blade.php
@@ -10,7 +10,12 @@
                         <img src="{{ $notice->image_url }}" alt="{{ $notice->title }}" class="w-full max-w-[160px] aspect-square object-cover border border-gray-200 bg-[#7cc0e6] mx-auto">
                     </div>
                     <div class="w-full md:w-3/4">
-                        <h6 class="text-lg text-gray-950 mb-1">{{ $notice->title }}</h6>
+                        <div class="flex items-center gap-2 mb-1">
+                            <h6 class="text-lg text-gray-950">{{ $notice->title }}</h6>
+                            @if($notice->is_pinned)
+                                <span class="text-[11px] uppercase tracking-wide bg-gray-900 text-white px-2 py-1 rounded">Fixada</span>
+                            @endif
+                        </div>
                         @if($notice->date)
                         <span class="block text-gray-700 mb-2">{{ \Carbon\Carbon::parse($notice->date)->format('d/m/Y') }}</span>
                         @endif

--- a/resources/views/noticies.blade.php
+++ b/resources/views/noticies.blade.php
@@ -13,7 +13,9 @@
                         <div class="flex items-center gap-2 mb-1">
                             <h6 class="text-lg text-gray-950">{{ $notice->title }}</h6>
                             @if($notice->is_pinned)
-                                <span class="text-[11px] uppercase tracking-wide bg-gray-900 text-white px-2 py-1 rounded">Fixada</span>
+                                <svg class="w-4 h-4 text-gray-700" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M16 12V4h1V2H7v2h1v8l-2 2v2h5.2v6h1.6v-6H18v-2l-2-2z"/>
+                                </svg>
                             @endif
                         </div>
                         @if($notice->date)


### PR DESCRIPTION
### Motivation
- Permitir fixar notícias no topo para destacar conteúdos importantes na página de notícias.
- Substituir a ordenação manual por número no Acervo por reordenação por arrastar para melhorar a usabilidade administrativa.
- Adicionar um e-mail de contato por membro da equipe para que cada funcionário possa ter um endereço exibido na página de contato.

### Description
- Notícias: adiciona colunas `is_pinned` e `sort_order` ao modelo e criação de migration (`database/migrations/2026_02_10_000001_add_pinning_and_sort_order_to_noticies_table.php`), inclui toggle `is_pinned` no `NoticiesResource` e torna a tabela reorderable por `sort_order`, atualiza `NoticieController@index` para ordenar por `is_pinned DESC`, `sort_order ASC`, `date DESC`, e adiciona badge "Fixada" em `resources/views/noticies.blade.php`.
- Acervo: remove o campo de input manual `order` no formulário do `CollectionResource` e habilita `->reorderable('order')` na tabela administrativa para permitir drag-and-drop.
- Contato/Equipe: adiciona migration para `email` em `teams` (`database/migrations/2026_02_10_000002_add_email_to_teams_table.php`), inclui `email` em `Team` model e no `TeamResource` (formulário + coluna), e exibe `mailto:` na view `resources/views/contact.blade.php` quando disponível.
- Vários arquivos PHP ajustados: `app/Models/Noticies.php`, `app/Models/Team.php`, `app/Filament/Resources/NoticiesResource.php`, `app/Filament/Resources/CollectionResource.php`, `app/Filament/Resources/TeamResource.php`, `app/Http/Controllers/NoticieController.php`, `resources/views/noticies.blade.php`, `resources/views/contact.blade.php`.

### Testing
- Executado `php -l` nos arquivos PHP alterados (resources, controllers, models e migrations) com resultado sem erros de sintaxe.
- Tentativa de executar `php artisan test` falhou por ausência de `vendor/autoload.php` e a instalação de dependências via `composer install` não pôde ser concluída devido à incompatibilidade entre o `composer.lock` (dependências travadas até PHP 8.4) e a versão do PHP do ambiente (8.5.x).
- Uma validação de interface automática foi executada com Playwright que acessou `http://127.0.0.1:8000/noticias` e capturou um screenshot (artefato gerado com sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b58af040483258e7d83cb8d599b6d)